### PR TITLE
Improve unicode string handling

### DIFF
--- a/lib/xml_node.ex
+++ b/lib/xml_node.ex
@@ -60,13 +60,17 @@ defmodule Feedme.XmlNode do
   defp extract_attr(_), do: nil
 
   def text(node), do: node |> xpath('./text()') |> extract_text
-  defp extract_text(fragments) do
+  defp extract_text(fragments) when is_list(fragments) do
     strings = Enum.map(fragments, fn(fragment) ->
                 xmlText(value: v) = fragment
                 List.to_string(v)
               end)
-    Enum.join(strings, "")
+    case Enum.join(strings, "") do
+      "" -> nil
+      x -> x
+    end
   end
+  defp extract_text(_x), do: nil
 
 
   def children_map(node, paths, callback) when is_list(paths) do

--- a/lib/xml_node.ex
+++ b/lib/xml_node.ex
@@ -60,8 +60,13 @@ defmodule Feedme.XmlNode do
   defp extract_attr(_), do: nil
 
   def text(node), do: node |> xpath('./text()') |> extract_text
-  defp extract_text([xmlText(value: value)]), do: List.to_string(value)
-  defp extract_text(_x), do: nil
+  defp extract_text(fragments) do
+    strings = Enum.map(fragments, fn(fragment) ->
+                xmlText(value: v) = fragment
+                List.to_string(v)
+              end)
+    Enum.join(strings, "")
+  end
 
 
   def children_map(node, paths, callback) when is_list(paths) do


### PR DESCRIPTION
I was getting `nil` results for unicode-containing strings - it looks as though xmerl returns them as an array of multiple `xmlText` fragments. This quick workaround iterates over them and then joins them back to a nice (unicode guaranteed) Elixir string. 